### PR TITLE
Replace Decoder.empty with Decoder.undefined and Decoder.null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-decoders",
-  "version": "3.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-decoders",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.1",
+  "version": "6.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,20 +301,35 @@ export class Decoder<T> {
   ]);
 
   /**
-   * A decoder that accepts undefined and null. Useful in conjunction with other
-   * decoders.
+   * A decoder that accepts undefined.
    *
    * Example:
    * ```
-   * Decoder.empty.run(null) // OK, value is undefined
-   * Decoder.empty.run(undefined) // OK, value is undefined
-   * Decoder.empty.run(5) // FAIL, value is not null or undefined
+   * Decoder.undefined.run(null) // FAIL
+   * Decoder.undefined.run(5) // FAIL
+   * Decoder.undefined.run(undefined) // OK
    *```
    */
-  public static empty: Decoder<undefined> = new Decoder((data) =>
-    data === null || data === undefined
-      ? Result.ok(undefined)
-      : Result.fail(makeSingleError('Not null or undefined', data))
+  public static undefined: Decoder<undefined> = new Decoder((data) =>
+    data === undefined
+      ? Result.ok(data)
+      : Result.fail(makeSingleError('Not undefined', data))
+  );
+
+  /**
+   * A decoder that accepts undefined.
+   *
+   * Example:
+   * ```
+   * Decoder.null.run(undefined) // FAIL
+   * Decoder.null.run(5) // FAIL
+   * Decoder.null.run(null) // OK
+   *```
+   */
+  public static null: Decoder<null> = new Decoder((data) =>
+    data === null
+      ? Result.ok(data)
+      : Result.fail(makeSingleError('Not null', data))
   );
 
   /**
@@ -364,7 +379,11 @@ export class Decoder<T> {
    * ```
    */
   public static optional = <T>(decoder: Decoder<T>): Decoder<T | undefined> =>
-    Decoder.oneOf([Decoder.empty, decoder]);
+    Decoder.oneOf([
+      Decoder.undefined,
+      Decoder.null.map((_) => undefined),
+      decoder,
+    ]);
 
   /**
    * Create a decoder that always fails with a message.

--- a/test/decoder.test.ts
+++ b/test/decoder.test.ts
@@ -197,18 +197,33 @@ describe('Array decoder', () => {
 });
 
 describe('Null decoder', () => {
-  it('decodes null and undefined', () => {
-    const res2 = Decoder.empty.run(undefined);
-    const res3 = Decoder.empty.run(null);
-    expect(res2).toEqual({ type: 'OK', value: undefined });
-    expect(res3).toEqual({ type: 'OK', value: undefined });
+  it('decodes null', () => {
+    const result = Decoder.null.run(null);
+    expect(result).toEqual({ type: 'OK', value: null });
   });
 
   it('does not decode invalid data', () => {
     fc.assert(
       fc.property(fc.anything(), (anything: any) => {
-        fc.pre(anything !== null && anything !== undefined);
-        const res = Decoder.empty.run(anything);
+        fc.pre(anything !== null);
+        const res = Decoder.null.run(anything);
+        expect(res).toHaveProperty('type', 'FAIL');
+      })
+    );
+  });
+});
+
+describe('Undefined decoder', () => {
+  it('decodes undefined', () => {
+    const result = Decoder.undefined.run(undefined);
+    expect(result).toEqual({ type: 'OK', value: undefined });
+  });
+
+  it('does not decode invalid data', () => {
+    fc.assert(
+      fc.property(fc.anything(), (anything: any) => {
+        fc.pre(anything !== undefined);
+        const res = Decoder.undefined.run(anything);
         expect(res).toHaveProperty('type', 'FAIL');
       })
     );


### PR DESCRIPTION
Increases granularity of values by separating handling of null and undefined 